### PR TITLE
фикс спонсорки

### DIFF
--- a/Content.Server/Database/ServerDbManager.cs
+++ b/Content.Server/Database/ServerDbManager.cs
@@ -1138,13 +1138,13 @@ namespace Content.Server.Database
 #if LOP
         public async Task<Sponsor?> GetSponsorInfo(NetUserId userId, CancellationToken cancel = default)
         {
-            DbWriteOpsMetric.Inc();
+            DbReadOpsMetric.Inc();
             return await _db.GetSponsorInfo(userId);
         }
 
         public async Task<Sponsor[]?> GetSponsorList(CancellationToken cancel = default)
         {
-            DbWriteOpsMetric.Inc();
+            DbReadOpsMetric.Inc();
             return await _db.GetSponsorList();
         }
 #endif

--- a/Content.Shared/Corvax/Preferences/Loadouts/Effects/SponsorLoadoutEffect.cs
+++ b/Content.Shared/Corvax/Preferences/Loadouts/Effects/SponsorLoadoutEffect.cs
@@ -15,8 +15,10 @@ public sealed partial class SponsorLoadoutEffect : LoadoutEffect
         LoadoutPrototype proto, // Corvax-Sponsors
         ICommonSession? session,
         IDependencyCollection collection,
-        [NotNullWhen(false)] out FormattedMessage? reason,
-        int sponsorTier = 0     // LOP edit
+        [NotNullWhen(false)] out FormattedMessage? reason
+        #if LOP
+        , int sponsorTier = 0
+        #endif
         )
     {
         reason = null;

--- a/Content.Shared/Corvax/Preferences/Loadouts/Effects/SponsorLoadoutEffect.cs
+++ b/Content.Shared/Corvax/Preferences/Loadouts/Effects/SponsorLoadoutEffect.cs
@@ -15,7 +15,9 @@ public sealed partial class SponsorLoadoutEffect : LoadoutEffect
         LoadoutPrototype proto, // Corvax-Sponsors
         ICommonSession? session,
         IDependencyCollection collection,
-        [NotNullWhen(false)] out FormattedMessage? reason)
+        [NotNullWhen(false)] out FormattedMessage? reason,
+        int sponsorTier = 0     // LOP edit
+        )
     {
         reason = null;
 

--- a/Content.Shared/Preferences/Loadouts/Effects/GroupLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/GroupLoadoutEffect.cs
@@ -13,14 +13,14 @@ public sealed partial class GroupLoadoutEffect : LoadoutEffect
     [DataField(required: true)]
     public ProtoId<LoadoutEffectGroupPrototype> Proto;
 
-    public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, LoadoutPrototype proto, ICommonSession? session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason) // Corvax-Sponsors
+    public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, LoadoutPrototype proto, ICommonSession? session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason, int sponsorTier = 0) // Corvax-Sponsors   //LOP edit
     {
         var effectsProto = collection.Resolve<IPrototypeManager>().Index(Proto);
 
         var reasons = new List<string>();
         foreach (var effect in effectsProto.Effects)
         {
-            if (effect.Validate(profile, loadout, proto, session, collection, out reason))
+            if (effect.Validate(profile, loadout, proto, session, collection, out reason, sponsorTier)) //LOP edit
                 continue;
 
             reasons.Add(reason.ToMarkup());

--- a/Content.Shared/Preferences/Loadouts/Effects/GroupLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/GroupLoadoutEffect.cs
@@ -13,14 +13,22 @@ public sealed partial class GroupLoadoutEffect : LoadoutEffect
     [DataField(required: true)]
     public ProtoId<LoadoutEffectGroupPrototype> Proto;
 
-    public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, LoadoutPrototype proto, ICommonSession? session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason, int sponsorTier = 0) // Corvax-Sponsors   //LOP edit
+    public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, LoadoutPrototype proto, ICommonSession? session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason 
+  #if LOP
+  , int sponsorTier = 0
+  #endif
+  )
     {
         var effectsProto = collection.Resolve<IPrototypeManager>().Index(Proto);
 
         var reasons = new List<string>();
         foreach (var effect in effectsProto.Effects)
         {
-            if (effect.Validate(profile, loadout, proto, session, collection, out reason, sponsorTier)) //LOP edit
+            if (effect.Validate(profile, loadout, proto, session, collection, out reason
+            #if LOP
+            , sponsorTier
+            #endif
+            ))
                 continue;
 
             reasons.Add(reason.ToMarkup());

--- a/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
@@ -19,7 +19,7 @@ public sealed partial class JobRequirementLoadoutEffect : LoadoutEffect
     #if LOP
     , int sponsorTier = 0
     #endif
-    )  //LOP edit
+    )
     {
         if (session == null
         #if LOP

--- a/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
@@ -15,9 +15,9 @@ public sealed partial class JobRequirementLoadoutEffect : LoadoutEffect
     [DataField(required: true)]
     public JobRequirement Requirement = default!;
 
-    public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, LoadoutPrototype proto, ICommonSession? session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason)
+    public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, LoadoutPrototype proto, ICommonSession? session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason, int sponsorTier = 0)  //LOP edit
     {
-        if (session == null)
+        if (session == null || sponsorTier >= 5)
         {
             reason = FormattedMessage.Empty;
             return true;
@@ -29,6 +29,8 @@ public sealed partial class JobRequirementLoadoutEffect : LoadoutEffect
             collection.Resolve<IPrototypeManager>(),
             profile,
             playtimes,
-            out reason);
+            out reason,
+            sponsorTier  //LOP edit
+            );
     }
 }

--- a/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/JobRequirementLoadoutEffect.cs
@@ -15,9 +15,18 @@ public sealed partial class JobRequirementLoadoutEffect : LoadoutEffect
     [DataField(required: true)]
     public JobRequirement Requirement = default!;
 
-    public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, LoadoutPrototype proto, ICommonSession? session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason, int sponsorTier = 0)  //LOP edit
+    public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, LoadoutPrototype proto, ICommonSession? session, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason
+    #if LOP
+    , int sponsorTier = 0
+    #endif
+    )  //LOP edit
     {
-        if (session == null || sponsorTier >= 5)
+        if (session == null
+        #if LOP
+        || sponsorTier >= 5
+        #endif
+        )
+
         {
             reason = FormattedMessage.Empty;
             return true;
@@ -29,8 +38,10 @@ public sealed partial class JobRequirementLoadoutEffect : LoadoutEffect
             collection.Resolve<IPrototypeManager>(),
             profile,
             playtimes,
-            out reason,
-            sponsorTier  //LOP edit
+            out reason
+            #if LOP
+            , sponsorTier
+            #endif
             );
     }
 }

--- a/Content.Shared/Preferences/Loadouts/Effects/LoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/LoadoutEffect.cs
@@ -16,7 +16,9 @@ public abstract partial class LoadoutEffect
         LoadoutPrototype proto, // Corvax-Sponsors
         ICommonSession? session,
         IDependencyCollection collection,
-        [NotNullWhen(false)] out FormattedMessage? reason);
+        [NotNullWhen(false)] out FormattedMessage? reason,
+        int sponsorTier = 0
+        );
 
-    public virtual void Apply(RoleLoadout loadout) {}
+    public virtual void Apply(RoleLoadout loadout) { }
 }

--- a/Content.Shared/Preferences/Loadouts/Effects/LoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/LoadoutEffect.cs
@@ -16,8 +16,10 @@ public abstract partial class LoadoutEffect
         LoadoutPrototype proto, // Corvax-Sponsors
         ICommonSession? session,
         IDependencyCollection collection,
-        [NotNullWhen(false)] out FormattedMessage? reason,
-        int sponsorTier = 0
+        [NotNullWhen(false)] out FormattedMessage? reason
+        #if LOP
+        , int sponsorTier = 0
+        #endif
         );
 
     public virtual void Apply(RoleLoadout loadout) { }

--- a/Content.Shared/Preferences/Loadouts/Effects/PointsCostLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/PointsCostLoadoutEffect.cs
@@ -16,7 +16,9 @@ public sealed partial class PointsCostLoadoutEffect : LoadoutEffect
         LoadoutPrototype proto, // Corvax-Sponsors
         ICommonSession? session,
         IDependencyCollection collection,
-        [NotNullWhen(false)] out FormattedMessage? reason)
+        [NotNullWhen(false)] out FormattedMessage? reason,
+        int sponsorTier = 0     // LOP edit
+        )
     {
         reason = null;
         var protoManager = collection.Resolve<IPrototypeManager>();

--- a/Content.Shared/Preferences/Loadouts/Effects/PointsCostLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/PointsCostLoadoutEffect.cs
@@ -16,8 +16,10 @@ public sealed partial class PointsCostLoadoutEffect : LoadoutEffect
         LoadoutPrototype proto, // Corvax-Sponsors
         ICommonSession? session,
         IDependencyCollection collection,
-        [NotNullWhen(false)] out FormattedMessage? reason,
-        int sponsorTier = 0     // LOP edit
+        [NotNullWhen(false)] out FormattedMessage? reason
+        #if LOP
+        , int sponsorTier = 0
+        #endif
         )
     {
         reason = null;

--- a/Content.Shared/Preferences/Loadouts/Effects/SpeciesLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/SpeciesLoadoutEffect.cs
@@ -12,7 +12,11 @@ public sealed partial class SpeciesLoadoutEffect : LoadoutEffect
     public List<ProtoId<SpeciesPrototype>> Species = new();
 
     public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, LoadoutPrototype proto, ICommonSession? session, IDependencyCollection collection, // Corvax-Sponsors
-        [NotNullWhen(false)] out FormattedMessage? reason, int sponsorTier = 0) // LOP edit
+        [NotNullWhen(false)] out FormattedMessage? reason
+        #if LOP
+        , int sponsorTier = 0
+        #endif
+        )
     {
         if (Species.Contains(profile.Species))
         {

--- a/Content.Shared/Preferences/Loadouts/Effects/SpeciesLoadoutEffect.cs
+++ b/Content.Shared/Preferences/Loadouts/Effects/SpeciesLoadoutEffect.cs
@@ -12,7 +12,7 @@ public sealed partial class SpeciesLoadoutEffect : LoadoutEffect
     public List<ProtoId<SpeciesPrototype>> Species = new();
 
     public override bool Validate(HumanoidCharacterProfile profile, RoleLoadout loadout, LoadoutPrototype proto, ICommonSession? session, IDependencyCollection collection, // Corvax-Sponsors
-        [NotNullWhen(false)] out FormattedMessage? reason)
+        [NotNullWhen(false)] out FormattedMessage? reason, int sponsorTier = 0) // LOP edit
     {
         if (Species.Contains(profile.Species))
         {

--- a/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
@@ -49,4 +49,12 @@ public sealed partial class LoadoutPrototype : IPrototype, IEquipmentLoadout
     /// <inheritdoc />
     [DataField]
     public Dictionary<string, List<EntProtoId>> Storage { get; set; } = new();
+
+    // LOP edit start
+    /// <summary>
+    /// Указатель UUID игрока, которому будет доступен лодаут
+    /// </summary>
+    [DataField("uuid")]
+    public string PlayerUUID = default!;
+    // LOP edit end
 }

--- a/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
+++ b/Content.Shared/Preferences/Loadouts/LoadoutPrototype.cs
@@ -55,6 +55,6 @@ public sealed partial class LoadoutPrototype : IPrototype, IEquipmentLoadout
     /// Указатель UUID игрока, которому будет доступен лодаут
     /// </summary>
     [DataField("uuid")]
-    public string PlayerUUID = default!;
+    public string? PlayerUUID = null;
     // LOP edit end
 }

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -162,7 +162,11 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
                 }
 
                 // Validate the loadout can be applied (e.g. points).
-                if (!IsValid(profile, session, loadout.Prototype, collection, out _, sponsorTier))
+                if (!IsValid(profile, session, loadout.Prototype, collection, out _
+                #if LOP
+                , sponsorTier
+                #endif
+                ))
                 {
                     loadouts.RemoveAt(i);
                     continue;
@@ -193,7 +197,11 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
                         continue;
 
                     // Not valid so don't default to it anyway.
-                    if (!IsValid(profile, session, defaultLoadout.Prototype, collection, out _, sponsorTier))
+                    if (!IsValid(profile, session, defaultLoadout.Prototype, collection, out _
+                    #if LOP
+                    , sponsorTier
+                    #endif
+                    ))
                         continue;
 
                     loadouts.Add(defaultLoadout);
@@ -276,7 +284,11 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
     /// <summary>
     /// Returns whether a loadout is valid or not.
     /// </summary>
-    public bool IsValid(HumanoidCharacterProfile profile, ICommonSession? session, ProtoId<LoadoutPrototype> loadout, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason, int sponsorTier = 0)
+    public bool IsValid(HumanoidCharacterProfile profile, ICommonSession? session, ProtoId<LoadoutPrototype> loadout, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason
+    #if LOP
+    , int sponsorTier = 0
+    #endif
+    )
     {
         reason = null;
 
@@ -310,7 +322,11 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
 
         foreach (var effect in loadoutProto.Effects)
         {
-            valid = valid && effect.Validate(profile, this, loadoutProto, session, collection, out reason, sponsorTier);
+            valid = valid && effect.Validate(profile, this, loadoutProto, session, collection, out reason
+            #if LOP
+            , sponsorTier
+            #endif
+            );
         }
 
         return valid;

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -308,7 +308,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
         }
 
         // LOP edit start
-        if (loadoutProto.PlayerUUID != default!)
+        if (loadoutProto.PlayerUUID != null)
         {
             if (session != null && loadoutProto.PlayerUUID == session.UserId.ToString())
                 return true;

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -162,7 +162,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
                 }
 
                 // Validate the loadout can be applied (e.g. points).
-                if (!IsValid(profile, session, loadout.Prototype, collection, out _))
+                if (!IsValid(profile, session, loadout.Prototype, collection, out _, sponsorTier))
                 {
                     loadouts.RemoveAt(i);
                     continue;
@@ -193,7 +193,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
                         continue;
 
                     // Not valid so don't default to it anyway.
-                    if (!IsValid(profile, session, defaultLoadout.Prototype, collection, out _))
+                    if (!IsValid(profile, session, defaultLoadout.Prototype, collection, out _, sponsorTier))
                         continue;
 
                     loadouts.Add(defaultLoadout);
@@ -276,7 +276,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
     /// <summary>
     /// Returns whether a loadout is valid or not.
     /// </summary>
-    public bool IsValid(HumanoidCharacterProfile profile, ICommonSession? session, ProtoId<LoadoutPrototype> loadout, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason)
+    public bool IsValid(HumanoidCharacterProfile profile, ICommonSession? session, ProtoId<LoadoutPrototype> loadout, IDependencyCollection collection, [NotNullWhen(false)] out FormattedMessage? reason, int sponsorTier = 0)
     {
         reason = null;
 
@@ -295,11 +295,22 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
             return false;
         }
 
+        // LOP edit start
+        if (loadoutProto.PlayerUUID != default!)
+        {
+            if (session != null && loadoutProto.PlayerUUID == session.UserId.ToString())
+                return true;
+
+            reason = FormattedMessage.FromUnformatted("Это принадлежит другому игроку");    //замените потом на ftl сами
+            return false;
+        }
+        // LOP edit end
+
         var valid = true;
 
         foreach (var effect in loadoutProto.Effects)
         {
-            valid = valid && effect.Validate(profile, this, loadoutProto, session, collection, out reason);
+            valid = valid && effect.Validate(profile, this, loadoutProto, session, collection, out reason, sponsorTier);
         }
 
         return valid;


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. Текст между стрелками - это комментарии - их нужно удалить. -->

**Описание обновления**
Менеджер спонсоров теперь не пишет, если у человека нет спонсорки, а также все проверки на уровень выполняются.
Также теперь в условиях на лодауты можно использовать уровень спонсорки.
Новая возможность: указание UUID в лодауте, чтобы сделать вещь личной и только для 1 человека.
Чтобы это сделать, в прототипе лодаута на строке после id укажите uuid: "<здесь UUID>".

**Проверки**
<!-- Выполнение всех следующих действий, если это приемлемо для вида изменений сильно ускорит разбор вашего PR -->
- [x] PR завершён и мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [x] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [x] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.
- [x] Я не добавлял контент нарушающий чужие авторские права.
- [x] Я не добавлял переводы в прототипы, а сделал их с помощью скрипта translations.bat в Tools/SS14_RU.
- [ ] Я не добавлял лишние изменения в PR. Т.е. 1 идея/задача на 1 PR.
- [x] Я прочитал CONTRIBUTING.md и следовал его правилам.

**Изменения**

:cl: Inari
- add: Добавлена возможность иметь личные лодауты
- fix: Исправлена выдача спонсорских элементов
